### PR TITLE
CLI: fixed help mismatch "libName" -> "name"

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -43,7 +43,7 @@ program.version(pkg.version)
   .option('-d, --dest <dest>', 'Destination')
   .parse(process.argv);
 
-libName = program.libName || libName || 'library';
+libName = program.name || libName || 'library';
 moduleName = program.moduleName || moduleName;
 format = program.format || format;
 dest = program.dest || dest;


### PR DESCRIPTION
Help used "name" but program expected "libName"
