### PR TITLE
Custom name

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -47,7 +47,7 @@ program.version(pkg.version)
     'Library name (defaults to `name` from `package.json` if available)')
   .option('--module-name <moduleName>', 'Module name for UMD build')
   .option('-f, --format <format>', 'Build formats (comma separated; default: es6,umd,cjs)')
-  .option('-p --postfix <postfix>', 'Postfix names (comma separated; default: es2015:.es6,umd:.umd,cjs:,iife:iife)')
+  .option('-p --postfix <postfix>', 'Postfix names (comma separated; default: es2015:.es6,umd:.umd,cjs:,iife:.iife)')
   .option('-d, --dest <dest>', 'Destination')
   .parse(process.argv);
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -13,6 +13,7 @@ var libName = '';
 var moduleName = '';
 var dest = '';
 var format = '';
+var postfix = '';
 var entry = '';
 var files = [];
 var packageConfig = {};
@@ -46,12 +47,14 @@ program.version(pkg.version)
     'Library name (defaults to `name` from `package.json` if available)')
   .option('--module-name <moduleName>', 'Module name for UMD build')
   .option('-f, --format <format>', 'Build formats (comma separated; default: es6,umd,cjs)')
+  .option('-p --postfix <postfix>', 'Postfix names (comma separated; default: es2015:.es6,umd:.umd,cjs:,iife:iife)')
   .option('-d, --dest <dest>', 'Destination')
   .parse(process.argv);
 
 libName = program.libName || libName || 'library';
 moduleName = program.moduleName || packageConfig.moduleName || moduleName;
 format = program.format || packageConfig.format || format;
+postfix = program.postfix || packageConfig.postfix || postfix;
 dest = program.dest || packageConfig.dest || dest;
 babelOptions = packageConfig.babel || babelOptions;
 
@@ -74,12 +77,27 @@ if (files.length > 0) {
       return format;
     })(format);
 
+    var bundlePostfix = (function (p) {
+      if (!p) {
+        return void 0;
+      }
+
+      if (typeof p === 'string') {
+        return p.split(',').reduce(function (prev, cur) {
+          var keyVal = cur.split(':');
+          prev[keyVal[0]] = keyVal[1];
+          return prev;
+        }, {});
+      }
+    }(postfix));
+
     rollupBabelLibBundler({
       name: libName,
       moduleName: moduleName,
       dest: dest,
       entry: arg,
       format: bundleFormat,
+      postfix: bundlePostfix,
       babel: babelOptions
     }).then(function buildThen(builds) {
       console.log('All done!');

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,12 @@ module.exports = function rollupLib(options) {
 
   var baseConfig = {};
   var builds = [];
+  var postfixDefaults = {
+    cjs: '',
+    es6: '.es2015',
+    umd: '.umd',
+    iife: '.iife'
+  };
 
   rollupOptions.name = rollupOptions.name || 'mylibrary';
   rollupOptions.moduleName = rollupOptions.moduleName || camelCase(rollupOptions.name);
@@ -23,6 +29,7 @@ module.exports = function rollupLib(options) {
   rollupOptions.entry = rollupOptions.entry || 'index.js';
   rollupOptions.format = rollupOptions.format || ['es6', 'cjs', 'umd'];
   rollupOptions.babel = rollupOptions.babel || 'inherit';
+  rollupOptions.postfix = objectAssign(postfixDefaults, rollupOptions.postfix);
 
   babelOptions = (rollupOptions.babel === 'inherit') ? void 0 : rollupOptions.babel;
 
@@ -43,22 +50,12 @@ module.exports = function rollupLib(options) {
 
     config.format = format;
     config.dest = path.join(rollupOptions.dest, rollupOptions.name);
-
-    if (format === 'es6') {
-      config.dest += '.es2015';
-    }
-
-    if (format === 'umd') {
-      config.dest += '.umd';
-      config.moduleName = rollupOptions.moduleName;
-    }
-
-    if (format === 'iife') {
-      config.dest += '.iife';
-      config.moduleName = rollupOptions.moduleName;
-    }
-
+    config.dest += rollupOptions.postfix[format];
     config.dest += '.js';
+
+    if (format === 'umd' || format === 'iife') {
+      config.moduleName = rollupOptions.moduleName;
+    }
 
     return rollup.rollup(config).then(function rollupBundle(bundle) {
       var endTime = 0;

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^5.2.0",
     "coveralls": "^2.11.8",
+    "del": "^2.2.0",
     "eslint": "^2.2.0",
     "eslint-config-airbnb": "^6.0.2",
     "eslint-plugin-react": "^4.1.0",

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,8 @@ chai.use(chaiAsPromised);
 
 var expect = chai.expect;
 var rollupBabelLibBundler = require('../lib');
+var del = require('del');
+var fs = require('fs');
 
 describe('rollup-babel-lib-bundler', function() {
   it('is a function', function() {
@@ -28,5 +30,22 @@ describe('rollup-babel-lib-bundler', function() {
     });
 
     expect(promise).to.eventually.be.a('array').and.notify(done);
+  });
+
+  it('adds the proper postfix', function(done) {
+    del.sync('./dist/*');
+
+    var expected = ['mylibrary.common.js', 'mylibrary.es2015.js'];
+    var promise = rollupBabelLibBundler({
+      entry: 'test/sample.js',
+      format: ['cjs', 'es6'],
+      postfix: {
+        cjs: '.common',
+      }
+    }).then(function () {
+      return fs.readdirSync('./dist');
+    });
+
+    expect(promise).to.eventually.be.eql(expected).and.notify(done);
   });
 });


### PR DESCRIPTION
## Allow user to provide custom postfix names

Falls back to original defaults if not provided for a certain format

This option can be passed to the API as an object, `postfix: { iife: '-browser', es6: '.es6' }`
Or to the CLI with the `--postfix` or `-p` flags like so: `--postfix iife:-browser,es6:.es6`

ex: 

``` js
rollupBabelLibBundler({
      entry: 'test/sample.js',
      format: ['cjs', 'es6'],
      postfix: {
        cjs: '.common'
      }
    }
});
```

``` shell
rollup-babel-lib-bundler example/myFancyLibrary.js -n myLib -f cjs,es6 -postfix cjs:.common
```

Will both output `mylib.common.js` and `mylib.es2015.js`

I also added a Chai test for this feature.

Let me know if you would like something renamed or have any questions or suggestions.
I can also add the documentation if you decide you want to pull it in.

✌️ 
