### PR TITLE
read postfix from package.json

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -89,6 +89,8 @@ if (files.length > 0) {
           return prev;
         }, {});
       }
+      
+      return p;
     }(postfix));
 
     rollupBabelLibBundler({


### PR DESCRIPTION
Small bugfix: CLI will now read postfix options from `package.json` if not supplied as an argument
